### PR TITLE
Improved readme on not supporting serve command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # gitbook-structured-toc
-A Table Of Contents module for Gitbook that adds headers as anchors
+
+A Table Of Contents module for Gitbook that adds headers as anchors.
+
+The plugin does not support `gitbook serve` command. If you've generated your book,
+you can view it by opening `_book/index.html`.


### PR DESCRIPTION
This pull request solves #2 by pointing out that `gitbook serve` is not supported by this plugin.